### PR TITLE
Fix updated theos and sdk

### DIFF
--- a/AppSyncUnified-installd/dump.h
+++ b/AppSyncUnified-installd/dump.h
@@ -1,8 +1,9 @@
+#include <CoreFoundation/CoreFoundation.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include <CoreFoundation/CoreFoundation.h>
 
 int copyEntitlementDataFromFile(const char *path, CFMutableDataRef output);
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
-export TARGET = iphone:clang:latest:16.0
-export ARCHS = arm64 arm64e
+ifeq ($(THEOS_PACKAGE_SCHEME),rootless)
+	ARCHS = arm64 arm64e
+	TARGET = iphone:clang:latest:15.0
+else
+	ARCHS = armv7 armv7s arm64 arm64e
+	TARGET = iphone:clang:latest:7.0
+endif
 export DEBUG = 0
 
 THEOS_PACKAGE_DIR_NAME = debs

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-export TARGET = iphone:clang:latest:5.0
-export ARCHS = armv7 armv7s arm64 arm64e
+export TARGET = iphone:clang:latest:16.0
+export ARCHS = arm64 arm64e
 export DEBUG = 0
 
 THEOS_PACKAGE_DIR_NAME = debs

--- a/appinst/Makefile
+++ b/appinst/Makefile
@@ -1,5 +1,10 @@
-export TARGET = iphone:clang:latest:16.0
-export ARCHS = arm64 arm64e
+ifeq ($(THEOS_PACKAGE_SCHEME),rootless)
+	ARCHS = arm64 arm64e
+	TARGET = iphone:clang:latest:15.0
+else
+	ARCHS = armv7 armv7s arm64 arm64e
+	TARGET = iphone:clang:latest:7.0
+endif
 export DEBUG = 0
 
 THEOS_PACKAGE_DIR_NAME = debs

--- a/appinst/Makefile
+++ b/appinst/Makefile
@@ -1,5 +1,5 @@
-export TARGET = iphone:clang:latest:5.0
-export ARCHS = armv7 armv7s arm64
+export TARGET = iphone:clang:latest:16.0
+export ARCHS = arm64 arm64e
 export DEBUG = 0
 
 THEOS_PACKAGE_DIR_NAME = debs

--- a/asu_inject/Makefile
+++ b/asu_inject/Makefile
@@ -1,4 +1,4 @@
-ARCHS = armv7 armv7s arm64
+ARCHS = arm64 arm64e
 
 include $(THEOS)/makefiles/common.mk
 

--- a/asu_inject/Makefile
+++ b/asu_inject/Makefile
@@ -1,4 +1,8 @@
-ARCHS = arm64 arm64e
+ifeq ($(THEOS_PACKAGE_SCHEME),rootless)
+	ARCHS = arm64 arm64e
+else
+	ARCHS = armv7 armv7s arm64 arm64e
+endif
 
 include $(THEOS)/makefiles/common.mk
 

--- a/asu_inject/asu_inject.c
+++ b/asu_inject/asu_inject.c
@@ -11,15 +11,19 @@
 #include <sys/param.h>
 #include <sys/types.h>
 
-#define DPKG_PATH ROOT_PATH("/var/lib/dpkg/info/ai.akemi.appsyncunified.list")
+
+#define DPKG_PATH ({ \
+	static char outPath[PATH_MAX]; \
+	libroot_dyn_jbrootpath("/var/lib/dpkg/info/ai.akemi.appsyncunified.list", outPath); \
+})
 
 extern char ***_NSGetEnviron(void);
 extern int proc_listallpids(void *, int);
 extern int proc_pidpath(int, void *, uint32_t);
 
-static const char *cynject_path = ROOT_PATH("/usr/bin/cynject");
-static const char *inject_criticald_path = ROOT_PATH("/electra/inject_criticald");
-static const char *dylib_path = ROOT_PATH("/Library/MobileSubstrate/DynamicLibraries/AppSyncUnified-installd.dylib");
+static const char *cynject_path;
+static const char *inject_criticald_path;
+static const char *dylib_path;
 static const char *dispatch_queue_name = NULL;
 static const char *process_name = "installd";
 static int process_buffer_size = 4096;
@@ -95,6 +99,10 @@ static void inject_dylib(const char *name, pid_t pid, const char *dylib) {
 }
 
 int main(int argc, char *argv[]) {
+	cynject_path = ROOT_PATH("/usr/bin/cynject");
+	inject_criticald_path = ROOT_PATH("/electra/inject_criticald");
+	dylib_path = ROOT_PATH("/Library/MobileSubstrate/DynamicLibraries/AppSyncUnified-installd.dylib");
+
 	printf("asu_inject for AppSync Unified\n");
 	printf("Copyright (C) 2014-2023 Karen/あけみ\n");
 	if (access(DPKG_PATH, F_OK) == -1) {

--- a/control
+++ b/control
@@ -1,5 +1,5 @@
 Conflicts: us.hackulo.appsync50, us.hackulo.appsync50plus, com.hackyouriphone.appsync7, com.teiron.ppsync, appsync50plus2.25pp, com.linusyang.appsync, com.sull.appsyncunified, com.sull.appsyncunifiedbeta, com.xsellize.appsync50, com.xsellize.appsync50plus, appsync50plus.178, appsync50plus2.178, cydia.net.angelxwind.appsyncunified, com.ifucker.appsync, com.sexyphonetech.appsyncunified, appsyncunifiedofficial, org.digbick.asufixed, cn.mingmei.asu623517234615234813, technology.goated.appsync, technology.goated.appsyncunified, vaginalfisting.appsynctool, science.xnu.substitute, akemi.appsink, akemi.appsyncunifed, akemi.appsyncunifed2, akemi.appsyncunifedpatched, appsyncpatched, appsyncrootless, weaponized.autism.technology.appsyncunified
-Depends: firmware (>= 5.0), mobilesubstrate (>= 0.9.5100), firmware (<= 16.5.1)
+Depends: firmware (>= 5.0), mobilesubstrate (>= 0.9.5100), firmware (<< 17.0)
 Depiction: https://cydia.akemi.ai/?page/ai.akemi.appsyncunified
 Maintainer: Karen/あけみ <karen@akemi.ai>
 Homepage: https://cydia.akemi.ai/

--- a/pkg-actions/Makefile
+++ b/pkg-actions/Makefile
@@ -1,4 +1,4 @@
-ARCHS = armv7 armv7s arm64
+ARCHS = arm64 arm64e
 
 include $(THEOS)/makefiles/common.mk
 

--- a/pkg-actions/Makefile
+++ b/pkg-actions/Makefile
@@ -1,4 +1,8 @@
-ARCHS = arm64 arm64e
+ifeq ($(THEOS_PACKAGE_SCHEME),rootless)
+	ARCHS = arm64 arm64e
+else
+	ARCHS = armv7 armv7s arm64 arm64e
+endif
 
 include $(THEOS)/makefiles/common.mk
 


### PR DESCRIPTION
## Description

I've updated the project to compile with the latest Xcode toolchains and the last Theos version.

Additionally it now should be able to install on all iOS 16 versions. Worked successfully on an iPhone 8 Plus running iOS 16.7.10 (the latest version as of today).

Building with `make package THEOS_PACKAGE_SCHEME=rootless` will make a rootless version targeting iOS 15 and up, `arm64` and `arm64e`.

Building using `make package` will build a traditional rootfull version targeting iOS 5 and up, `arm7`, `armv7s`, `arm64` and `arm64e`. You need an older version of the Xcode toolchain for this.